### PR TITLE
prog: add NOSTRIP option

### DIFF
--- a/man/prog.7mk/prog.7mk.xml
+++ b/man/prog.7mk/prog.7mk.xml
@@ -42,6 +42,14 @@
 				<term><code>DEBUG</code></term>
 
 				<listitem>
+					<para>Adjusts the build to add and preserve debugging
+						information. Implies <code>NOSTRIP</code>.</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
+				<term><code>NOSTRIP</code></term>
+
+				<listitem>
 					<para>Don&rsquo;t strip symbols.
 						Symbols are stripped by default.</para>
 				</listitem>

--- a/share/mk/prog.mk
+++ b/share/mk/prog.mk
@@ -12,7 +12,7 @@ CLEAN += ${BUILD}/bin/${prog}
 
 ${BUILD}/bin/${prog}:
 	${CC} -o $@ ${LFLAGS} ${.ALLSRC:M*.o} ${.ALLSRC:M*.a} ${LFLAGS_${prog}}
-.if !defined(DEBUG)
+.if !defined(DEBUG) && !defined(NOSTRIP)
 	${STRIP} $@
 .endif
 


### PR DESCRIPTION
There is value in retaining symbols / other data otherwise removed by
strip(1) in non-debug builds. This option allows us to avoid stripping
the binary even when not including debugging stabs.