### PR TITLE
Use cc instead of ld for creating shared libraries

### DIFF
--- a/share/mk/so.mk
+++ b/share/mk/so.mk
@@ -5,7 +5,7 @@
 # See LICENCE for the full copyright terms.
 #
 
-LD ?= ld
+SOLD ?= ${CC}
 UNAME ?= uname
 UNAME_SYSTEM != ${UNAME} -s
 SYSTEM ?= ${UNAME_SYSTEM}
@@ -39,7 +39,7 @@ lib::    ${BUILD}/lib/${lib}.${LIBEXT}
 CLEAN += ${BUILD}/lib/${lib}.${LIBEXT}
 
 ${BUILD}/lib/${lib}.${LIBEXT}: ${BUILD}/lib/${lib}.opic
-	${LD} -o $@ ${LDSFLAGS} ${LDSFLAGS.${lib}} ${.ALLSRC:M*.opic}
+	${SOLD} -o $@ ${LDSFLAGS} ${LDSFLAGS.${lib}} ${.ALLSRC:M*.opic}
 
 STAGE_BUILD += lib/${lib}.${LIBEXT}
 


### PR DESCRIPTION
Simple change to use ${CC} to created shared objects rather than using `ld` directly, so that the compiler driver has the opportunity to do things the way it wants them done.