### PR TITLE
lx.mk: The generated lexer.c should depend on lexer.h.

### DIFF
--- a/share/mk/lx.mk
+++ b/share/mk/lx.mk
@@ -25,6 +25,8 @@ gen:: ${lexer:R}.${ext}
 
 .endfor
 
+${lexer:R}.c: ${lexer:R}.h
+
 test::
 	${LX} -l test < ${lexer}
 


### PR DESCRIPTION
This is causing the build to get stuck on libfsm, because the the .c and .h have fallen out of sync, but building doesn't cause the stale file to regenerate.