### PR TITLE
Fix Broken MacOS Build

### DIFF
--- a/share/mk/so.mk
+++ b/share/mk/so.mk
@@ -23,7 +23,8 @@ LIBEXT ?= so
 .endif
 
 .if ${SYSTEM} == Darwin
-LDSFLAGS ?= -dylib -flat_namespace -undefined dynamic_lookup
+XCODE_SELECT_P != xcode-select -p
+LDSFLAGS ?= -dylib -flat_namespace -undefined dynamic_lookup -L${XCODE_SELECT_P}/SDKs/MacOSX.sdk/usr/lib -lSystem
 .else
 LDSFLAGS ?= -shared
 .endif


### PR DESCRIPTION
The existing `LDSFLAGS` is not working -- the `$(xcode-select -p)` within it is evaluating as "" -- it doesn't even seem to be executed.  bmake problem?

Fixed by using the != execute-and-assign operator, and also by adding -lSystem parameter.