### PR TITLE
Add flags for libfuzzer when `FUZZER` is set.

### DIFF
--- a/share/mk/obj.mk
+++ b/share/mk/obj.mk
@@ -85,6 +85,9 @@ CFLAGS += -fsanitize=memory -fPIE
 .if defined(UBSAN)
 CFLAGS += -fsanitize=undefined,float-divide-by-zero,unsigned-integer-overflow,implicit-conversion,bounds
 .endif
+.if defined(FUZZER)
+CFLAGS += -fsanitize=fuzzer
+.endif
 .endif
 
 .if defined(DEBUG)

--- a/share/mk/prog.mk
+++ b/share/mk/prog.mk
@@ -41,6 +41,10 @@ LFLAGS += -fsanitize=undefined,float-divide-by-zero,unsigned-integer-overflow,im
 LFLAGS += -lefence
 .endif
 
+.if ${CC:T:Mclang} && defined(FUZZER)
+LFLAGS += -fsanitize=fuzzer
+.endif
+
 .for prog in ${PROG}
 
 .if ${CC:T:Memcc*}


### PR DESCRIPTION
Also, make the `CC` matching against clang less strict.