### PR TITLE
prog.mk: For `FUZZER` target, match `clang*` not `clang`.

### DIFF
--- a/share/mk/prog.mk
+++ b/share/mk/prog.mk
@@ -41,7 +41,7 @@ LFLAGS += -fsanitize=undefined,float-divide-by-zero,unsigned-integer-overflow,im
 LFLAGS += -lefence
 .endif
 
-.if ${CC:T:Mclang} && defined(FUZZER)
+.if ${CC:T:Mclang*} && defined(FUZZER)
 LFLAGS += -fsanitize=fuzzer
 .endif
 


### PR DESCRIPTION
Otherwise, this breaks the build with e.g. `CC="clang-10"`.